### PR TITLE
chore: use gci to order imports

### DIFF
--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -19,11 +19,12 @@ import (
 	"context"
 	"fmt"
 
+	goplugin "github.com/hashicorp/go-plugin"
+
 	"github.com/abcxyz/jvs-plugin-jira/pkg/plugin"
 	jvspb "github.com/abcxyz/jvs/apis/v0"
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
-	goplugin "github.com/hashicorp/go-plugin"
 )
 
 type ServerCommand struct {

--- a/pkg/plugin/config_test.go
+++ b/pkg/plugin/config_test.go
@@ -18,9 +18,10 @@ package plugin
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestPluginConfig_ToFlags(t *testing.T) {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -24,9 +24,10 @@ import (
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
-	jvspb "github.com/abcxyz/jvs/apis/v0"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
 )
 
 const (

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"testing"
 
-	jvspb "github.com/abcxyz/jvs/apis/v0"
-	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
 )
 
 type mockValidator struct {

--- a/pkg/plugin/validator_test.go
+++ b/pkg/plugin/validator_test.go
@@ -21,9 +21,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestValidation(t *testing.T) {


### PR DESCRIPTION
Golang-CI change is introduced to abcxyz/pkg by: https://github.com/abcxyz/pkg/pull/247